### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/commit-message-check.yml
+++ b/.github/workflows/commit-message-check.yml
@@ -1,4 +1,6 @@
 name: Commit Message Check
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/loqalabs/loqa/security/code-scanning/1](https://github.com/loqalabs/loqa/security/code-scanning/1)

To fix the issue, add an explicit `permissions` key with the minimum required permissions for the job. For this workflow, since it only needs to read repository content (commits, etc.), you should set `contents: read`. The best way is to add this block either at the root of the workflow (to apply to all jobs) or within the specific job requiring it. Given that this workflow has only one job and no indication of other jobs needing separate settings, add the following below the `name:` field at the root level (i.e., after line 1). No additional imports, definitions, or method changes are needed—just a single YAML block addition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
