### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,8 @@ jobs:
   validate:
     name: Validate Documentation
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
     - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/loqalabs/loqa/security/code-scanning/5](https://github.com/loqalabs/loqa/security/code-scanning/5)

The best way to fix this issue is to add an explicit `permissions:` block to the `validate` job in `.github/workflows/ci.yml`. Since the job only needs to read the repository contents to run its checks, the minimal permission required is `contents: read`. This block should be placed within the `validate` job definition (at the same indentation level as `runs-on`) and preferably before the `steps` key for consistency with the structure used in the other jobs (such as `spell-check`). No other code needs to change.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
