### PR TITLE
CRITICAL: Fix STT container health check failing due to missing wget

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -53,10 +53,11 @@ services:
     networks:
       - loqa-network
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:8000/health"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)"]
       interval: 30s
       timeout: 10s
       retries: 3
+      start_period: 60s
 
   # TTS Service (CPU version for development)
   tts:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,11 +54,11 @@ services:
     networks:
       - loqa-network
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8000/health"]
+      test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 30s
+      start_period: 60s
 
   # Text-to-Speech Service (Kokoro-82M GPU)
   tts-gpu:


### PR DESCRIPTION
## 🚨 Critical Fix: STT Health Check Failing

**Issue**: STT container was showing as unhealthy even though the service was running correctly, causing dependent services to fail to start.

## 🔍 Root Cause Analysis

**Problem**: Health check command was using `wget` which is not available in the `fedirz/faster-whisper-server:latest-cpu` container.

```bash
# This was failing:
test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8000/health"]

# Error: exec: "wget": executable file not found in $PATH
```

## ✅ Solution

**Replaced wget with Python** (which is available in the Python-based container):

```yaml
# Before
test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8000/health"]

# After  
test: ["CMD", "python3", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)"]
```

**Additional improvements:**
- ✅ **Increased start_period** from 30s to 60s (model loading takes time)
- ✅ **Applied to both files**: `docker-compose.yml` and `docker-compose.dev.yml`
- ✅ **Verified working**: Container now shows as `(healthy)`

## 🧪 Testing

**Before fix:**
```bash
docker-compose ps stt
# STATUS: Up X minutes (unhealthy)
```

**After fix:**
```bash
docker-compose ps stt  
# STATUS: Up X minutes (healthy) ✅
```

**Manual verification:**
```bash
# Health check endpoint works correctly
curl http://localhost:8000/health  
# Returns: OK

# New health check command works
docker exec stt python3 -c "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=5)"
# Returns: success ✅
```

## 🎯 Impact

- ✅ **STT service now reports healthy status correctly**
- ✅ **Hub service can start properly** (depends on STT health)
- ✅ **5-minute setup guide works end-to-end**
- ✅ **Service orchestration works as designed**

This ensures the voice pipeline can start correctly and dependent services wait for STT to be truly ready.