### PR TITLE
Standardize Docker volume names to use loqa prefix

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -204,16 +204,16 @@ services:
 volumes:
   ollama-data:
     external: true
-    name: ${COMPOSE_PROJECT_NAME}_ollama-data
+    name: loqa_ollama-data
   hub-data:
     external: true
-    name: ${COMPOSE_PROJECT_NAME}_hub-data
+    name: loqa_hub-data
   stt-cache:
     external: true
-    name: ${COMPOSE_PROJECT_NAME}_stt-cache
+    name: loqa_stt-cache
   tts-cache:
     external: true
-    name: ${COMPOSE_PROJECT_NAME}_tts-cache
+    name: loqa_tts-cache
 
 networks:
   loqa-network:

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -56,10 +56,10 @@ echo "📦 Creating Docker volumes..."
 PROJECT_NAME=$(basename "$(pwd)")
 
 # Create volumes that Docker Compose will use (prevents warning messages)
-docker volume create "${PROJECT_NAME}_ollama-data" >/dev/null 2>&1 || true
-docker volume create "${PROJECT_NAME}_hub-data" >/dev/null 2>&1 || true
-docker volume create "${PROJECT_NAME}_stt-cache" >/dev/null 2>&1 || true
-docker volume create "${PROJECT_NAME}_tts-cache" >/dev/null 2>&1 || true
+docker volume create "loqa_ollama-data" >/dev/null 2>&1 || true
+docker volume create "loqa_hub-data" >/dev/null 2>&1 || true
+docker volume create "loqa_stt-cache" >/dev/null 2>&1 || true
+docker volume create "loqa_tts-cache" >/dev/null 2>&1 || true
 
 echo "📥 Pulling latest Docker images..."
 docker-compose pull


### PR DESCRIPTION
## Summary

- Updates docker-compose.yml to use consistent "loqa_" prefix for all volumes instead of directory-dependent naming
- Updates setup.sh to create volumes with matching names
- Simplifies volume management and avoids naming conflicts

## Changes

- `docker-compose.yml`: Changed volume names from `loqalabs_*` to `loqa_*`
- `tools/setup.sh`: Updated volume creation to use consistent naming

## Benefits

- Consistent volume naming regardless of parent directory structure
- Easier volume management and cleanup
- Avoids confusion with directory-dependent prefixes
- Simplifies fresh setup process

## Testing

- [ ] Clean volume setup works correctly
- [ ] Services start without volume conflicts
- [ ] Volume persistence works as expected