### PR TITLE
Automate service startup ordering and add system readiness visibility

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,10 +28,11 @@ services:
     networks:
       - loqa-network
     healthcheck:
-      test: ["CMD", "ollama", "list"]
+      test: ["CMD", "sh", "-c", "ollama list | grep -q 'llama3.2:3b' && curl -f http://localhost:11434/api/generate -X POST -H 'Content-Type: application/json' -d '{\"model\":\"llama3.2:3b\",\"prompt\":\"test\",\"stream\":false}' --max-time 5 --silent --output /dev/null"]
       interval: 30s
-      timeout: 10s
-      retries: 3
+      timeout: 15s
+      retries: 5
+      start_period: 120s  # Allow time for model download
     # Pull model on startup
     entrypoint: ["/bin/sh", "-c"]
     command: >

--- a/tools/Makefile
+++ b/tools/Makefile
@@ -1,4 +1,4 @@
-.PHONY: help setup setup-dev build start start-dev stop clean test proto dev logs
+.PHONY: help setup setup-dev build start start-dev stop clean test proto dev logs status
 
 # Default target
 help:
@@ -15,6 +15,7 @@ help:
 	@echo "  proto     - Regenerate protocol buffers"
 	@echo "  dev       - Start development environment"
 	@echo "  logs      - View service logs"
+	@echo "  status    - Check system readiness and health"
 
 setup:
 	@echo "🦜 5-minute Loqa setup with pre-built images..."
@@ -75,6 +76,10 @@ dev: start
 logs:
 	@echo "📊 Showing service logs..."
 	cd .. && docker-compose logs -f
+
+status:
+	@echo "🔍 Checking Loqa system status..."
+	cd .. && ./tools/status.sh
 
 # Individual service commands
 start-hub:

--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -67,49 +67,30 @@ docker-compose pull
 echo "🐳 Starting Loqa services..."
 docker-compose up -d
 
-echo "⏳ Waiting for services to start..."
-sleep 15
+echo "⏳ Waiting for services to be ready..."
+echo "   This may take a few minutes for the LLM model to download and load..."
+echo ""
 
-# Check if services are running
-echo "🔍 Checking service health..."
+# Wait a moment for services to start
+sleep 10
 
-# Function to check HTTP endpoints
-check_endpoint() {
-    local url=$1
-    local service_name=$2
-    
-    if command -v curl &> /dev/null; then
-        if curl -s -f "$url" > /dev/null 2>&1; then
-            echo "✅ $service_name is running"
-        else
-            echo "⚠️  $service_name may still be starting..."
-        fi
-    else
-        echo "ℹ️  $service_name status check skipped (no curl available)"
-    fi
-}
-
-check_endpoint "http://localhost:3000/health" "Hub service"
-check_endpoint "http://localhost:11434/api/tags" "Ollama service"
-check_endpoint "http://localhost:8000/health" "STT service"
-check_endpoint "http://localhost:8880/v1/audio/voices" "TTS service (Kokoro)"
+# Run comprehensive status check
+echo "🔍 Running system readiness check..."
+if ./tools/status.sh; then
+    echo ""
+    echo "🎉 Loqa setup complete and ready!"
+else
+    echo ""
+    echo "⚠️  Setup completed, but some services are still starting."
+    echo "   Run './tools/status.sh' again in a minute to check readiness"
+fi
 
 echo ""
-echo "🎉 Loqa setup complete!"
-echo ""
-echo "Services running:"
-echo "  🧠 Hub API: http://localhost:3000"
-echo "  🕹️  Commander UI: http://localhost:5173"  
-echo "  📡 gRPC Audio: localhost:50051"
-echo "  🤖 Ollama: http://localhost:11434"
-echo "  📨 NATS: localhost:4222"
-echo ""
-echo "Next steps:"
-echo "  📱 Open the Commander UI to see your voice assistant in action"
-echo "  🎙️  Use a test relay to send voice commands (requires audio setup)"
-echo ""
-echo "To stop services:"
-echo "  docker-compose down"
+echo "📖 Quick reference:"
+echo "  • Check system status: ./tools/status.sh"
+echo "  • Commander UI: http://localhost:5173"
+echo "  • Check logs: docker-compose logs -f"
+echo "  • Stop services: docker-compose down"
 echo ""
 echo "For development setup with source code:"
 echo "  Use: docker-compose -f docker-compose.dev.yml up -d"

--- a/tools/status.sh
+++ b/tools/status.sh
@@ -1,0 +1,150 @@
+#!/bin/bash
+
+# Loqa System Status Checker
+# Shows real-time status of all services and overall system readiness
+
+set -e
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m' # No Color
+
+# Emojis for status
+LOADING="🔄"
+SUCCESS="✅"
+ERROR="❌"
+WARNING="⚠️"
+READY="🚀"
+
+echo "🔍 Loqa System Status Check"
+echo "=================================="
+
+# Function to check service health
+check_service_health() {
+    local service_name="$1"
+    local container_name="$2"
+
+    if docker ps --format "table {{.Names}}\t{{.Status}}" | grep -q "$container_name.*healthy"; then
+        echo -e "${SUCCESS} $service_name: ${GREEN}Healthy${NC}"
+        return 0
+    elif docker ps --format "table {{.Names}}\t{{.Status}}" | grep -q "$container_name.*starting\|unhealthy"; then
+        echo -e "${LOADING} $service_name: ${YELLOW}Starting...${NC}"
+        return 1
+    elif docker ps --format "table {{.Names}}\t{{.Status}}" | grep -q "$container_name"; then
+        echo -e "${WARNING} $service_name: ${YELLOW}Running (no health check)${NC}"
+        return 1
+    else
+        echo -e "${ERROR} $service_name: ${RED}Not running${NC}"
+        return 1
+    fi
+}
+
+# Function to check specific functionality
+check_ollama_model() {
+    if curl -s http://localhost:11434/api/tags | grep -q "llama3.2:3b"; then
+        # Test if model can actually generate
+        if curl -s -X POST http://localhost:11434/api/generate \
+           -H "Content-Type: application/json" \
+           -d '{"model":"llama3.2:3b","prompt":"test","stream":false}' \
+           --max-time 10 >/dev/null 2>&1; then
+            echo -e "${SUCCESS} LLM Model: ${GREEN}llama3.2:3b loaded and responding${NC}"
+            return 0
+        else
+            echo -e "${WARNING} LLM Model: ${YELLOW}llama3.2:3b loaded but not responding${NC}"
+            return 1
+        fi
+    else
+        echo -e "${ERROR} LLM Model: ${RED}llama3.2:3b not available${NC}"
+        return 1
+    fi
+}
+
+check_voice_pipeline() {
+    local stt_ok=false
+    local tts_ok=false
+
+    # Check STT
+    if curl -s http://localhost:8000/health >/dev/null 2>&1; then
+        echo -e "${SUCCESS} Speech-to-Text: ${GREEN}Ready${NC}"
+        stt_ok=true
+    else
+        echo -e "${ERROR} Speech-to-Text: ${RED}Not responding${NC}"
+    fi
+
+    # Check TTS
+    if curl -s http://localhost:8880/v1/audio/voices >/dev/null 2>&1; then
+        echo -e "${SUCCESS} Text-to-Speech: ${GREEN}Ready${NC}"
+        tts_ok=true
+    else
+        echo -e "${ERROR} Text-to-Speech: ${RED}Not responding${NC}"
+    fi
+
+    if $stt_ok && $tts_ok; then
+        return 0
+    else
+        return 1
+    fi
+}
+
+# Check if docker-compose is running
+if ! docker ps >/dev/null 2>&1; then
+    echo -e "${ERROR} Docker is not running"
+    exit 1
+fi
+
+echo "📋 Service Health Status:"
+echo "------------------------"
+
+# Check each service
+services_ready=0
+total_services=6
+
+check_service_health "NATS Message Bus" "nats" && ((services_ready++))
+check_service_health "Ollama LLM" "ollama" && ((services_ready++))
+check_service_health "Speech-to-Text" "stt" && ((services_ready++))
+check_service_health "Text-to-Speech" "tts" && ((services_ready++))
+check_service_health "Hub Service" "hub" && ((services_ready++))
+check_service_health "Commander UI" "commander" && ((services_ready++))
+
+echo ""
+echo "🧠 AI/Voice Pipeline Status:"
+echo "-----------------------------"
+
+pipeline_ready=0
+total_pipeline=2
+
+check_ollama_model && ((pipeline_ready++))
+check_voice_pipeline && ((pipeline_ready++))
+
+echo ""
+echo "📊 System Readiness Summary:"
+echo "=============================="
+
+if [ $services_ready -eq $total_services ] && [ $pipeline_ready -eq $total_pipeline ]; then
+    echo -e "${READY} ${GREEN}System is READY for voice commands!${NC}"
+    echo -e "   ${SUCCESS} All services healthy ($services_ready/$total_services)"
+    echo -e "   ${SUCCESS} Voice pipeline operational ($pipeline_ready/$total_pipeline)"
+    echo ""
+    echo -e "${BLUE}🎤 To test voice commands:${NC}"
+    echo -e "   ${BLUE}cd loqa-relay/test-go && go run ./cmd -hub localhost:50051${NC}"
+    echo -e "   ${BLUE}Say: \"Hey Loqa, turn on the kitchen lights\"${NC}"
+    exit 0
+elif [ $services_ready -eq $total_services ]; then
+    echo -e "${WARNING} ${YELLOW}Services ready, but pipeline initializing...${NC}"
+    echo -e "   ${SUCCESS} All services healthy ($services_ready/$total_services)"
+    echo -e "   ${WARNING} Voice pipeline: ($pipeline_ready/$total_pipeline) ready"
+    echo ""
+    echo -e "${YELLOW}💡 Wait a moment for LLM model to fully load, then try again${NC}"
+    exit 1
+else
+    echo -e "${ERROR} ${RED}System NOT ready${NC}"
+    echo -e "   ${WARNING} Services: ($services_ready/$total_services) healthy"
+    echo -e "   ${WARNING} Voice pipeline: ($pipeline_ready/$total_pipeline) ready"
+    echo ""
+    echo -e "${YELLOW}🔧 Run: docker-compose up -d${NC}"
+    echo -e "${YELLOW}⏳ Then wait for all services to become healthy${NC}"
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Eliminates the startup race condition where hub service starts before Ollama model is fully loaded, and provides clear user visibility into system readiness.

## Key Changes

### 🔧 **Improved Service Dependencies**
- **Enhanced Ollama health check**: Now verifies model is loaded AND responding to inference requests
- **Extended timeouts**: Allows proper time for model download and loading (120s start period)
- **Actual functionality test**: Health check performs real model inference, not just API availability

### 🚀 **System Readiness Visibility**
- **New status script** (`tools/status.sh`): Comprehensive system health checker with color-coded output
- **Enhanced setup experience**: Setup script now shows clear readiness status instead of basic endpoint checks
- **Make command integration**: `make status` for easy system health monitoring

### 🎯 **User Experience Improvements**
- **Clear readiness indicators**: Users know exactly when system is ready for voice commands
- **Actionable feedback**: Specific guidance based on current system state
- **No more guesswork**: Eliminates need to dig through logs to understand system status

## Before/After

**Before**: Users had to restart hub service manually after Ollama loaded, or check logs to understand startup issues.

**After**: System automatically waits for all components to be ready, with clear visual feedback.

## Benefits

- ✅ **Eliminates startup race conditions**
- ✅ **Clear user feedback on readiness**  
- ✅ **Reduces support burden** (no more "why isn't it working" questions)
- ✅ **Better developer experience** with `make status`
- ✅ **Proactive problem identification**

## Testing

- [ ] Fresh setup with `./tools/setup.sh`
- [ ] System status checking with `./tools/status.sh`
- [ ] Make command integration with `make status`
- [ ] Voice pipeline functionality after readiness confirmation