### PR TITLE
Fix status.sh availability for 5-minute setup users

### DIFF
--- a/tools/setup.sh
+++ b/tools/setup.sh
@@ -74,20 +74,25 @@ echo ""
 # Wait a moment for services to start
 sleep 10
 
+# Download status checker for ongoing use
+echo "📥 Setting up status checker..."
+curl -fsSL "https://raw.githubusercontent.com/loqalabs/loqa/main/tools/status.sh" -o status.sh
+chmod +x status.sh
+
 # Run comprehensive status check
 echo "🔍 Running system readiness check..."
-if ./tools/status.sh; then
+if ./status.sh; then
     echo ""
     echo "🎉 Loqa setup complete and ready!"
 else
     echo ""
     echo "⚠️  Setup completed, but some services are still starting."
-    echo "   Run './tools/status.sh' again in a minute to check readiness"
+    echo "   Run './status.sh' again in a minute to check readiness"
 fi
 
 echo ""
 echo "📖 Quick reference:"
-echo "  • Check system status: ./tools/status.sh"
+echo "  • Check system status: ./status.sh"
 echo "  • Commander UI: http://localhost:5173"
 echo "  • Check logs: docker-compose logs -f"
 echo "  • Stop services: docker-compose down"


### PR DESCRIPTION
## Summary

Fixes the issue where users following the 5-minute quick start guide can't access the status.sh script because they don't clone the repository.

## Problem

Users running the 5-minute setup via:
```bash
curl -fsSL "https://raw.githubusercontent.com/loqalabs/loqa/main/tools/setup.sh" | bash
```

Don't have access to `./tools/status.sh` since they don't clone the repo locally.

## Solution

- **Download status.sh during setup** - curl the script from GitHub during setup
- **Update all references** - change from `./tools/status.sh` to `./status.sh` 
- **Make executable** - ensure proper permissions after download

## Changes

- Setup script now downloads status.sh to current directory
- User instructions updated to reference `./status.sh` instead of `./tools/status.sh`
- Ensures 5-minute setup users have full system status checking capability

## Testing

- [x] Remote setup via curl works with status checking
- [x] Downloaded status.sh has proper permissions and functionality
- [x] User can run `./status.sh` after setup completion

This ensures the complete 5-minute setup experience works as intended.