### PR TITLE
Add HUB_SERVICE_NAME environment variable for Commander UI

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -133,6 +133,7 @@ services:
       - "5173:80"
     environment:
       - VITE_HUB_API_URL=http://localhost:3000
+      - HUB_SERVICE_NAME=hub
     depends_on:
       hub:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -171,6 +171,7 @@ services:
       - "5173:80"
     environment:
       - VITE_HUB_API_URL=http://localhost:3000
+      - HUB_SERVICE_NAME=hub
     depends_on:
       hub:
         condition: service_healthy


### PR DESCRIPTION
## Summary

Adds the `HUB_SERVICE_NAME` environment variable to Commander UI service configuration to enable parameterized nginx proxy configuration.

## Problem

Commander UI was failing to start because:
- nginx config hard-coded `loqa-hub` as upstream service name
- Docker Compose uses `hub` as the container name  
- Commander UI couldn't resolve the non-existent hostname

## Solution

- **Add environment variable**: `HUB_SERVICE_NAME=hub` in both docker-compose files
- **Enable parameterization**: Allows Commander nginx config to use env variable instead of hard-coding
- **Coordinate with companion PR**: Works with nginx template changes in loqa-commander

## Changes

- `docker-compose.yml`: Add `HUB_SERVICE_NAME=hub` to commander service environment
- `docker-compose.dev.yml`: Add `HUB_SERVICE_NAME=hub` to commander service environment

## Coordination Required

This change coordinates with: loqalabs/loqa-commander#39

**Merge Order**: 
1. First: loqalabs/loqa-commander#39 (nginx template changes)
2. Second: This PR (environment variable provision)

## Benefits

- ✅ **Fixes Commander UI startup failures**
- ✅ **Eliminates hard-coded service dependencies**  
- ✅ **Enables flexible service naming**
- ✅ **Improves deployment configuration flexibility**

## Testing

- [x] Commander UI starts successfully with HUB_SERVICE_NAME environment variable
- [x] API proxy correctly routes to hub:3000 instead of loqa-hub:3000
- [x] Both production and development compose files updated consistently